### PR TITLE
Add support for emoji skintone

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -28,7 +28,17 @@ describe('remark-a11y-emoji', () => {
     });
   });
 
-  it('should return HTML for "👩🏾‍💻"', done => {
+  it('should return HTML for emojis with skin tones', done => {
+    const input = '✌🏾';
+    const expected = '<span role="img" aria-label="victory hand (skin tone 5)">✌🏾</span>';
+
+    processor.process(input, (_, file) => {
+      expect(String(file)).toContain(expected);
+      done();
+    });
+  });
+
+  it('should return HTML for emojis without variant selector', done => {
     const input = '👩🏾‍💻';
     const expected = '<span role="img" aria-label="woman technologist (skin tone 5)">👩🏾‍💻</span>';
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -28,6 +28,16 @@ describe('remark-a11y-emoji', () => {
     });
   });
 
+  it('should return HTML for "👩🏾‍💻"', done => {
+    const input = '👩🏾‍💻';
+    const expected = '<span role="img" aria-label="woman technologist (skin tone 5)">👩🏾‍💻</span>';
+
+    processor.process(input, (_, file) => {
+      expect(String(file)).toContain(expected);
+      done();
+    });
+  });
+
   it('should return HTML for "foo 🎸 bar 🎧 qoo"', done => {
     const input = 'foo 🎸 bar 🎧 qoo';
     const expected =

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,28 @@ const emojiRegex = require('emoji-regex');
 const gemoji = require('gemoji');
 const visit = require('unist-util-visit');
 
+const { stripSkintone, skintoneMap } = require('./skintone');
+
 function a11yEmoji() {
+  function getEmojiDescription(emoji) {
+    const { skintone, genericEmoji } = stripSkintone(emoji);
+
+    const info = gemoji.unicode[genericEmoji];
+
+    if (!info) {
+      return '';
+    }
+
+    const skintoneDescription = skintoneMap[skintone] || '';
+    return skintoneDescription
+      ? `${info.description} (${skintoneDescription})`
+      : info.description;
+  }
+
   function visitor(node) {
     node.value = node.value.replace(emojiRegex(), match => {
       node.type = 'html';
-      const description = gemoji.unicode[match]
-        ? gemoji.unicode[match].description
-        : '';
+      const description = getEmojiDescription(match);
       return `<span role="img" aria-label="${description}">${match}</span>`;
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,15 @@ function a11yEmoji() {
   function getEmojiDescription(emoji) {
     const { skintone, genericEmoji } = stripSkintone(emoji);
 
-    const info = gemoji.unicode[genericEmoji];
+    let info = gemoji.unicode[genericEmoji];
 
     if (!info) {
-      return '';
+      const appleEmoji = genericEmoji + '\uFE0F';
+      info = gemoji.unicode[appleEmoji];
+
+      if (!info) {
+        return ''
+      }
     }
 
     const skintoneDescription = skintoneMap[skintone] || '';

--- a/src/skintone.js
+++ b/src/skintone.js
@@ -1,0 +1,22 @@
+const skintoneMap = {
+  '🏻': 'skin tone 2',
+  '🏼': 'skin tone 3',
+  '🏽': 'skin tone 4',
+  '🏾': 'skin tone 5',
+  '🏿': 'skin tone 6',
+}
+
+function stripSkintone(emoji) {
+  const skintoneRegex = new RegExp(Object.keys(skintoneMap).join('|'), 'g');
+  const genericEmoji = emoji.replace(skintoneRegex, '');
+
+  let skintone = emoji.match(skintoneRegex);
+  skintone = skintone === null ? undefined : skintone[0]
+
+  return { skintone, genericEmoji };
+}
+
+module.exports = {
+  skintoneMap,
+  stripSkintone,
+}


### PR DESCRIPTION
## Context

Currently, this library generates blank `aria-label` strings for emojis with skin tones because the emoji dictionary this library is reliant upon,`gemoiji`, doesn't support emojis with skin tones. 

This PR strips the skin tone unicode from emojis before querying `gemoji` so a description can be generated for the `aria-label`.

## Concerns

[Apple adds a variant selector](https://github.com/mathiasbynens/emoji-regex/issues/28#issuecomment-321435043), `\uFE0F`, to some emojis; Apple's unicode is what's [used in `gemoji`](https://github.com/wooorm/gemoji/blob/main/support.md).  

| Source | Emoji | Unicode | 
|-|-|-|
| Mac-selected skin tone emoji |✌🏾 | `\u270C\uD83C\uDFFE`|
| Stripped emoji |✌ | `\u270C` |
| Mac-selected emoji |✌️ | `\u270C\uFE0F` |

`gemoji` is first queried with the stripped emojis in case there was no skin color on the emoji or it doesn't include the variant. If that fails to get a match, the variant is added and `gemoji` is queried again. An empty `aria-label` is the fallback.