### PR TITLE
Output hast tree instead of HTML

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ]
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -26,13 +26,18 @@ yarn add --dev @fec/remark-a11y-emoji
 
 ## Configuration
 
-You can use `@fec/remark-a11y-emoji` like any other Remark plugin:
+You can use `@fec/remark-a11y-emoji` like any other Remark plugin. The plugin produces an AST ([hast](https://github.com/syntax-tree/hast), [rehype](https://github.com/rehypejs/rehype)), which you can serialize to HTML with [rehype-stringify](https://github.com/rehypejs/rehype/tree/main/packages/rehype-stringify):
 
 ```js
-const remark = require('remark');
-const a11yEmoji = require('@fec/remark-a11y-emoji');
+import remark from 'remark';
+import a11yEmoji from '@fec/remark-a11y-emoji';
+import rehypeStringify from 'rehype-stringify';
+import remarkRehype from 'remark-rehype';
 
-const processor = remark().use(a11yEmoji);
+const processor = remark()
+    .use(a11yEmoji)
+    .use(remarkRehype)
+    .use(rehypeStringify);
 ```
 
 # Contributing

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -1,79 +1,73 @@
-import plugin from '../src';
+import rehypeStringify from 'rehype-stringify';
 import remark from 'remark';
-import html from 'remark-html';
-import gemoji from 'gemoji';
+import remarkRehype from 'remark-rehype';
+import plugin from '../src';
 
-jest.mock('gemoji', ()=>([
-  { emoji: '🎸', description: 'guitar' },
-  { emoji: '✌️', description: 'victory hand' },
-  { emoji: '👩‍💻', description: 'woman technologist' },
-  { emoji: '🎧', description: 'headphone' },
-]), { virtual: true })
+jest.mock(
+  'gemoji',
+  () => [
+    { emoji: '🎸', description: 'guitar' },
+    { emoji: '✌️', description: 'victory hand' },
+    { emoji: '👩‍💻', description: 'woman technologist' },
+    { emoji: '🎧', description: 'headphone' },
+  ],
+  { virtual: true }
+);
 
 describe('remark-a11y-emoji', () => {
-
   const processor = remark()
-    .use(html)
-    .use(plugin);
+    .use(plugin)
+    .use(remarkRehype)
+    .use(rehypeStringify);
 
-  it('should return HTML for "🎸"', done => {
+  it('should return HTML for "🎸"', async () => {
     const input = '🎸';
     const expected = '<span role="img" aria-label="guitar">🎸</span>';
 
-    processor.process(input, (_, file) => {
-      expect(String(file)).toContain(expected);
-      done();
-    });
+    const { contents } = await processor.process(input);
+    expect(contents).toContain(expected);
   });
 
-  it('should return HTML for emojis with skin tones', done => {
+  it('should return HTML for emojis with skin tones', async () => {
     const input = '✌🏾';
-    const expected = '<span role="img" aria-label="victory hand (skin tone 5)">✌🏾</span>';
+    const expected =
+      '<span role="img" aria-label="victory hand (skin tone 5)">✌🏾</span>';
 
-    processor.process(input, (_, file) => {
-      expect(String(file)).toContain(expected);
-      done();
-    });
+    const { contents } = await processor.process(input);
+    expect(contents).toContain(expected);
   });
 
-  it('should return HTML for emojis without variant selector', done => {
+  it('should return HTML for emojis without variant selector', async () => {
     const input = '👩🏾‍💻';
-    const expected = '<span role="img" aria-label="woman technologist (skin tone 5)">👩🏾‍💻</span>';
+    const expected =
+      '<span role="img" aria-label="woman technologist (skin tone 5)">👩🏾‍💻</span>';
 
-    processor.process(input, (_, file) => {
-      expect(String(file)).toContain(expected);
-      done();
-    });
+    const { contents } = await processor.process(input);
+    expect(contents).toContain(expected);
   });
 
-  it('should return HTML for "foo 🎸 bar 🎧 qoo"', done => {
+  it('should return HTML for "foo 🎸 bar 🎧 qoo"', async () => {
     const input = 'foo 🎸 bar 🎧 qoo';
     const expected =
       'foo <span role="img" aria-label="guitar">🎸</span> bar <span role="img" aria-label="headphone">🎧</span> qoo';
 
-    processor.process(input, (_, file) => {
-      expect(String(file)).toContain(expected);
-      done();
-    });
+    const { contents } = await processor.process(input);
+    expect(contents).toContain(expected);
   });
 
-  it('should use empty string as label if emoji does not exist', done => {
+  it('should use empty string as label if emoji does not exist', async () => {
     const input = '🚨';
     const expected = '<span role="img" aria-label="">🚨</span>';
 
-    processor.process(input, (_, file) => {
-      expect(String(file)).toContain(expected);
-      done();
-    });
+    const { contents } = await processor.process(input);
+    expect(contents).toContain(expected);
   });
 
- it('should return do nothing to other nodes', done => {
+  it('should return do nothing to other nodes', async () => {
     const input = 'foo **bar**';
     const expected = 'foo <strong>bar</strong>';
 
-    processor.process(input, (_, file) => {
-      expect(String(file)).toContain(expected);
-      done();
-    });
+    const { contents } = await processor.process(input);
+    expect(contents).toContain(expected);
   });
 });

--- a/package.json
+++ b/package.json
@@ -41,14 +41,15 @@
     "@rollup/plugin-node-resolve": "^11.0.0",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
+    "rehype-stringify": "^8.0.0",
     "remark": "^13.0.0",
-    "remark-html": "^13.0.1",
+    "remark-rehype": "^8.0.0",
     "rollup": "^2.34.0"
   },
   "dependencies": {
     "emoji-regex": "^9.2.0",
     "gemoji": "^6.1.0",
-    "unist-util-visit": "^2.0.3"
+    "mdast-util-find-and-replace": "^1.0.0"
   },
   "engines": {
     "node": ">=10.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,43 +1,47 @@
 import emojiRegex from 'emoji-regex';
 import gemoji from 'gemoji';
-import visit from 'unist-util-visit';
-import { stripSkintone, skintoneMap } from './skintone';
+import findAndReplace from 'mdast-util-find-and-replace';
+import { skintoneMap, stripSkintone } from './skintone';
 
 function emojiToName(emoji) {
-  return gemoji.find(item => item.emoji === emoji);
+  return gemoji.find((item) => item.emoji === emoji);
+}
+
+function getEmojiDescription(emoji) {
+  const { skintone, genericEmoji } = stripSkintone(emoji);
+
+  let info = emojiToName(genericEmoji);
+
+  if (!info) {
+    const appleEmoji = genericEmoji + '\uFE0F';
+    info = emojiToName(appleEmoji);
+
+    if (!info) {
+      return '';
+    }
+  }
+
+  const skintoneDescription = skintoneMap[skintone] || '';
+  return skintoneDescription
+    ? `${info.description} (${skintoneDescription})`
+    : info.description;
 }
 
 function a11yEmoji() {
-  function getEmojiDescription(emoji) {
-    const { skintone, genericEmoji } = stripSkintone(emoji);
-
-    let info = emojiToName(genericEmoji);
-
-    if (!info) {
-      const appleEmoji = genericEmoji + '\uFE0F';
-      info = emojiToName(appleEmoji);
-
-      if (!info) {
-        return '';
-      }
-    }
-
-    const skintoneDescription = skintoneMap[skintone] || '';
-    return skintoneDescription
-      ? `${info.description} (${skintoneDescription})`
-      : info.description;
-  }
-
-  function visitor(node) {
-    node.value = node.value.replace(emojiRegex(), match => {
-      node.type = 'html';
-      const description = getEmojiDescription(match);
-      return `<span role="img" aria-label="${description}">${match}</span>`;
-    });
+  function replace(match) {
+    return {
+      type: 'text',
+      value: match,
+      data: {
+        hName: 'span',
+        hProperties: { role: 'img', ariaLabel: getEmojiDescription(match) },
+        hChildren: [{ type: 'text', value: match }],
+      },
+    };
   }
 
   function transform(markdownAST) {
-    visit(markdownAST, 'text', visitor);
+    findAndReplace(markdownAST, emojiRegex(), replace);
   }
 
   return transform;


### PR DESCRIPTION
In response to https://github.com/florianeckerstorfer/gatsby-remark-a11y-emoji/issues/66 the plugin now returns a AST ([hast](https://github.com/syntax-tree/hast), [rehype](https://github.com/rehypejs/rehype)) instead of HTML.